### PR TITLE
Bump minimum CMake version to 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(segyio LANGUAGES C CXX)
 
 include(CheckFunctionExists)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ A copy of segyio is available both as pre-built binaries and source code:
 To build segyio you need:
  * A C99 compatible C compiler (tested mostly on gcc and clang)
  * A C++ compiler for the Python extension, and C++11 for the tests
- * [CMake](https://cmake.org/) version 2.8.12 or greater
+ * [CMake](https://cmake.org/) version 3.11 or greater
  * [Python](https://www.python.org/) 3.9 or greater
  * [numpy](http://www.numpy.org/) version 1.10 or greater
  * [setuptools](https://pypi.python.org/pypi/setuptools) version 28 or greater

--- a/external/catch2/CMakeLists.txt
+++ b/external/catch2/CMakeLists.txt
@@ -1,12 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.11)
 project(catch2 CXX)
 
-# Dummy source file added because INTERFACE type
-# library is not available in CMake 2.8.12
-# it's STATIC, because MSVC would otherwise not generate a .lib file, making
-# "linking" (for header path) fail later
-#
-# TODO: when cmake minimum version is bumped to 3.x series, replace with
-# an INTERFACE library
-add_library(catch2 STATIC dummy.cpp)
-target_include_directories(catch2 SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(catch2 INTERFACE)
+target_include_directories(catch2 SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(libsegyio C CXX)
 
 set(SEGYIO_LIB_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE PATH "")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,7 +7,7 @@ if (SKBUILD)
     return ()
 endif ()
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
 project(segyio-python)
 
 if (REQUIRE_PYTHON)

--- a/python/setup-CMakeLists.txt
+++ b/python/setup-CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.11)
 project(segyio-python-extension LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Red Hat Enterprise Linux (RHEL) 7 has reached its end of life in 2024. This means we can bump the minimum required version to 3.11 which is provided in RHEL 8 [1]. We assume that other systems either have CMake 3.11 or newer available, or have a way to install a sufficently new CMake versions.

Bumping the minimum version removes some deprecation warning and also ensures compatibility with CMake 4.0 which has dropped support for CMake <3.5 and was rolled out to GitHub runners recently.

[1]: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/8.0_release_notes/index#platform-tools